### PR TITLE
imagickのインストールをコンテナに追加

### DIFF
--- a/docker/mysql/initdb.d/initialize.sql
+++ b/docker/mysql/initdb.d/initialize.sql
@@ -1,17 +1,1 @@
-DROP TABLE IF EXISTS `tb_tasks`;
-
-DROP TABLE IF EXISTS `tb_score_history`;
-CREATE TABLE `tb_tasks` (
-  `id` int unsigned NOT NULL AUTO_INCREMENT,
-  `title` text,
-  `description` text,
-  `end_date` datetime,
-  `completed` tinyint(1),
-  `weight` tinyint(1),
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-INSERT INTO `tb_tasks` (title, description, end_date, completed, weight) VALUES
-  ('webアプリ勉強会はじめました', 'タスクアプリを作る', '2020-11-25 12:00:00', 0, 1),
-  ('画面を表示させる', 'HTMLを使う', '2020-11-25 12:00:00', 0, 2),
-  ('綺麗な画面を作る', 'CSSを使う', '2020-11-25 12:00:00', 0, 3);
+CREATE DATABASE support;

--- a/docker/support-php/Dockerfile
+++ b/docker/support-php/Dockerfile
@@ -40,10 +40,19 @@ RUN apk update                       && \
         gmp-dev                         \
         libmemcached-dev                \
         imagemagick-dev                 \
+        libpng                          \
+        libjpeg                         \
+        libgcc                          \
+        libgomp                         \
         libzip-dev                      \
         libssh2                         \
         libssh2-dev                     \
         libxslt-dev                  && \
+    \
+    apk add --no-cache --virtual build-dependencies \
+    jpeg-dev                                        \
+    libpng-dev                                      \
+    imagemagick-dev                              && \
     \
     tar xfz /tmp/5.1.1.tar.gz   && \
     \
@@ -90,7 +99,10 @@ RUN apk update                       && \
         apcu imagick                                            &&  \
     \
     docker-php-ext-enable                                           \
-        apcu imagick                                            &&  \
+        apcu                                                    &&  \
+    \
+    docker-php-ext-enable                                           \
+        --ini-name 20-imagick.ini imagick                       &&  \
     \
     apk del .build-dependencies                                 &&  \
     \

--- a/docker/support-php/Dockerfile
+++ b/docker/support-php/Dockerfile
@@ -113,6 +113,8 @@ RUN apk update                       && \
 # unix socket connection settings
 COPY ./php-fpm.d/zzz-www.conf /usr/local/etc/php-fpm.d/zzz-www.conf
 
+WORKDIR /var/www/support-tool
+
 # set recommended PHP.ini settings
 COPY conf.d/* /usr/local/etc/php/conf.d/
 CMD  ["php-fpm"]


### PR DESCRIPTION
## 対応内容・背景
support-toolコンテナ内でphpコマンドを実行するとimagickのWarningが出ていたため対応

▼エラー内容
```bash
/var/www/support-tool # php -r 'phpinfo();' | grep memory_limit
PHP Warning:  PHP Startup: Unable to load dynamic library 'imagick' (tried: /usr/local/lib/php/extensions/no-debug-non-zts-20180731/imagick (Error loading shared library /usr/local/lib/php/extensions/no-debug-non-zts-20180731/imagick: No such file or directory), /usr/local/lib/php/extensions/no-debug-non-zts-20180731/imagick.so (Error loading shared library libgomp.so.1: No such file or directory (needed by /usr/local/lib/php/extensions/no-debug-non-zts-20180731/imagick.so))) in Unknown on line 0
memory_limit => 128M => 128M
```

## やったこと

コンテナ作成時にimagickとそれに必要なライブラリをインストールする

### Main fix
* imagcik追加手順は下記２つを踏襲する形で		
  * https://polidog.jp/2018/05/08/php-docker-imagick/	
  * https://thr3a.hatenablog.com/entry/20200725/1595663265	
* imagcikインストールに必要なライブラリは下記を参考		
  * https://www.rainorshine.asia/2018/05/07/post2951.html	

### Second fix
* supportコンテナのWORKDIRを設定
* dbコンテナの初期化SQLを修正してsupport-tool用のDBを作成するように


## 確認・スクショ
- [x] ローカルで起動を確認
- [x] サーバ(EC2)上で起動を確認